### PR TITLE
fix(ci): sanitize release tag version before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,10 +221,14 @@ jobs:
       - name: Sync version from tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver tag: $VERSION"
+            exit 1
+          fi
           cd npm
-          node -e "
+          VERSION="$VERSION" node -e "
             const pkg = require('./package.json');
-            pkg.version = '$VERSION';
+            pkg.version = process.env.VERSION;
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "Publishing memory-mcp@${VERSION} to npm"


### PR DESCRIPTION
### Motivation
- Закрити критичну вразливість у CI, коли ім’я тега вставлялося напряму в `node -e` як частина JS-коду і могло виконати довільний Node.js код під час кроку «Sync version from tag». 
- Забезпечити, щоб лише коректні semver-теги проходили до кроку публікації і що версія передається як дані, а не як виконуване джерело.

### Description
- Додано перевірку формату тега за regex-ом `^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$` і аварійний вихід при невідповідності, щоб відхилити зловмисні теги. 
- Видалено пряме вставлення `'$VERSION'` у JS-код і замінено на передачу через середовище: `VERSION="$VERSION" node -e "... pkg.version = process.env.VERSION; ..."`. 
- Зміна зберігає поведінку для допустимих тегів (`v1.2.3`, `v1.2.3-rc.1`) і блокує потенційні ін’єкції коду. 
- Зміни закомічено і підготовлено PR з описом безпекового впливу.

### Testing
- Підтверджено вміст файлу через `sed -n '1,280p' .github/workflows/release.yml` та `nl -ba .github/workflows/release.yml | sed -n '216,245p'`, які показали додану валідацію і передачу версії через `process.env.VERSION` (успішно). 
- Перевірено диф командою `git diff -- .github/workflows/release.yml` та виконано `git commit` з повідомленням `fix(ci): prevent tag injection in npm release step` (успішно). 
- PR створено автоматично (`make_pr`) з описом виправлення та безпекового пояснення (успішно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dcc3ed48832b861a1ea44eb057a1)