### PR TITLE
fix(ci): harden cache seeding workflow trust boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs if new commits are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -51,7 +56,7 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          key: seed-${{ matrix.target }}
           cache-on-failure: false
 
       # Build dependencies only (skip compiling the binary and skip LTO linking)
@@ -84,6 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -96,7 +103,7 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: x86_64-unknown-linux-musl
+          key: seed-x86_64-unknown-linux-musl
           cache-on-failure: false
 
       - name: Compile dependencies


### PR DESCRIPTION
### Motivation
- Усунути CI supply‑chain ризик від розкладу/ручного cache‑seed воркфлоу шляхом зменшення прав токена, вимкнення передачі облікових даних у checkout і відокремлення ключів кешу від релізних кешів.

### Description
- Внесено мінімальні зміни в ` .github/workflows/ci.yml`: додано `permissions: contents: read`, встановлено `persist-credentials: false` для `actions/checkout@v4` у seed jobs, та префіксовано ключі кешу як `seed-...` (наприклад `seed-${{ matrix.target }}`) щоб уникнути перетину з релізними кешами.

### Testing
- Автоматично перевірено/інспектовано файли та операції за допомогою команд (`sed`/`nl` перегляд ` .github/workflows/ci.yml` та ` .github/workflows/release.yml`), `rg` для знаходження `AGENTS.md`, `git status` і успішного `git commit`, всі перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dc74a2e4832bb9940d9f04b1bbde)