### PR TITLE
fix(security): перевірка завантажень npm-бінарника та зміцнення обробки тегів релізу

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,16 @@ jobs:
           
           echo "Packaging $BIN_PATH to $ASSET_NAME"
           tar -czf "$ASSET_NAME" -C $(dirname "$BIN_PATH") "$BINARY_NAME"
-          
+          sha256sum "$ASSET_NAME" > "$ASSET_NAME.sha256"
+
           echo "ASSET_NAME=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ASSET_NAME }}
+          files: |
+            ${{ env.ASSET_NAME }}
+            ${{ env.ASSET_NAME }}.sha256
 
   docker-release:
     needs: build-musl
@@ -194,16 +197,20 @@ jobs:
           
           if [ "${{ matrix.archive_ext }}" = ".zip" ]; then
             7z a "$ASSET_NAME" "$BIN_PATH"
+            sha256sum "$ASSET_NAME" > "$ASSET_NAME.sha256"
           else
             tar -czf "$ASSET_NAME" -C $(dirname "$BIN_PATH") "$BINARY_NAME"
+            shasum -a 256 "$ASSET_NAME" | awk '{print $1 "  " $2}' > "$ASSET_NAME.sha256"
           fi
-          
+
           echo "ASSET_NAME=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.ASSET_NAME }}
+          files: |
+            ${{ env.ASSET_NAME }}
+            ${{ env.ASSET_NAME }}.sha256
 
   # 📦 Publish npm wrapper package
   npm-publish:
@@ -219,12 +226,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync version from tag
+        env:
+          VERSION: ${{ github.ref_name }}
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=${VERSION#v}
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || { echo "Invalid semver tag: $VERSION"; exit 1; }
           cd npm
-          node -e "
+          VERSION="$VERSION" node -e "
             const pkg = require('./package.json');
-            pkg.version = '$VERSION';
+            pkg.version = process.env.VERSION;
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "Publishing memory-mcp@${VERSION} to npm"

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -8,12 +8,11 @@
  */
 
 const https = require("https");
-const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 const os = require("os");
-const zlib = require("zlib");
+const crypto = require("crypto");
 
 const REPO = "pomazanbohdan/memory-mcp-1file";
 const BINARY_NAME = "memory-mcp";
@@ -50,21 +49,36 @@ function getVersion() {
     return pkg.version;
 }
 
-function getDownloadUrl(version, target) {
+function getAssetName(version, target) {
     const ext = target.includes("windows") ? ".zip" : ".tar.gz";
-    return `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${version}-${target}${ext}`;
+    return `${BINARY_NAME}-${version}-${target}${ext}`;
+}
+
+function getDownloadUrl(version, target) {
+    return `https://github.com/${REPO}/releases/download/v${version}/${getAssetName(version, target)}`;
+}
+
+function getChecksumUrl(version, target) {
+    return `${getDownloadUrl(version, target)}.sha256`;
 }
 
 /**
  * Follow redirects (GitHub releases use 302 → S3).
  */
-function download(url) {
+function download(url, redirectCount = 0) {
     return new Promise((resolve, reject) => {
-        const client = url.startsWith("https") ? https : http;
+        if (redirectCount > 5) {
+            return reject(new Error(`Too many redirects for ${url}`));
+        }
+        if (!url.startsWith("https://")) {
+            return reject(new Error(`Refusing non-HTTPS download URL: ${url}`));
+        }
+        const client = https;
         client
             .get(url, { headers: { "User-Agent": "memory-mcp-npm" } }, (res) => {
                 if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                    return download(res.headers.location).then(resolve, reject);
+                    const redirect = new URL(res.headers.location, url).toString();
+                    return download(redirect, redirectCount + 1).then(resolve, reject);
                 }
                 if (res.statusCode !== 200) {
                     return reject(
@@ -78,6 +92,19 @@ function download(url) {
             })
             .on("error", reject);
     });
+}
+
+
+function sha256Hex(buffer) {
+    return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function parseChecksumFile(text) {
+    const token = text.trim().split(/\s+/)[0];
+    if (!/^[a-fA-F0-9]{64}$/.test(token)) {
+        throw new Error("Invalid SHA256 checksum format");
+    }
+    return token.toLowerCase();
 }
 
 /**
@@ -136,7 +163,16 @@ async function main() {
     console.log(`  URL: ${url}`);
 
     try {
-        const buffer = await download(url);
+        const [buffer, checksumBuffer] = await Promise.all([
+            download(url),
+            download(getChecksumUrl(version, target)),
+        ]);
+
+        const expected = parseChecksumFile(checksumBuffer.toString("utf8"));
+        const actual = sha256Hex(buffer);
+        if (actual !== expected) {
+            throw new Error(`Checksum mismatch for downloaded binary (expected ${expected}, got ${actual})`);
+        }
 
         if (isWindows) {
             await extractZip(buffer, binDir);


### PR DESCRIPTION
### Motivation
- Усунути ризик підміни нативного бінарника під час `npm install` шляхом додавання перевірки цілісності завантаженого артефакту. 
- Заблокувати можливість CI-кодуін’єкції через небезпечну інтерполяцію тега при публікації пакета на npm.

### Description
- Додано генерацію та завантаження SHA-256 sidecar файлів для релізних артефактів у `.github/workflows/release.yml` (завантажуються разом з архівами). 
- У `npm/postinstall.js` вимога `https://` для всіх завантажень, обмеження глибини редиректів, побудова URL для `.sha256` sidecar та перевірка SHA-256 перед розпакуванням і наданням права виконання. 
- Змінено крок синхронізації версії в workflow, тепер версія береться з `github.ref_name`, перевіряється простим semver-regex у shell і передається в Node через `process.env.VERSION` замість прямої рядкової інтерполяції. 
- Зміни закомічено під повідомленням `fix(security): verify npm binary downloads and harden tag handling` і затронули `npm/postinstall.js` та `.github/workflows/release.yml`.

### Testing
- `node --check npm/postinstall.js` пройшов успішно (синтаксична перевірка). 
- `node --check npm/run.js` пройшов успішно (синтаксична перевірка). 
- Перевірено `git diff` та `git status` щоб підтвердити очікувані зміни у `npm/postinstall.js` та `.github/workflows/release.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e309bef8832baaa13a33bfce6594)