### PR TITLE
fix(security): enforce input size limits for memory and search text

### DIFF
--- a/src/server/logic/memory.rs
+++ b/src/server/logic/memory.rs
@@ -15,11 +15,24 @@ use crate::types::{Memory, MemoryType, MemoryUpdate};
 
 use super::{error_response, normalize_limit, strip_embedding, strip_embeddings, success_json};
 
+const MAX_MEMORY_CONTENT_CHARS: usize = 16_000;
+
+fn validate_memory_content(content: &str) -> anyhow::Result<()> {
+    if content.chars().count() > MAX_MEMORY_CONTENT_CHARS {
+        anyhow::bail!(
+            "content is too long (max {} characters)",
+            MAX_MEMORY_CONTENT_CHARS
+        );
+    }
+    Ok(())
+}
+
 pub async fn store_memory(
     state: &Arc<AppState>,
     params: StoreMemoryParams,
 ) -> anyhow::Result<CallToolResult> {
     crate::ensure_embedding_ready!(state);
+    validate_memory_content(&params.content)?;
 
     let embedding = state.embedding.embed(&params.content).await?;
 
@@ -69,6 +82,7 @@ pub async fn update_memory(
     params: UpdateMemoryParams,
 ) -> anyhow::Result<CallToolResult> {
     let (embedding, content_hash, embedding_state) = if let Some(ref new_content) = params.content {
+        validate_memory_content(new_content)?;
         let old_memory = state.storage.get_memory(&params.id).await?;
         let old_hash = old_memory.as_ref().and_then(|m| m.content_hash.as_deref());
 

--- a/src/server/logic/search.rs
+++ b/src/server/logic/search.rs
@@ -13,6 +13,18 @@ use crate::types::{MemoryType, ScoredMemory, SearchResult};
 
 use super::{error_response, normalize_limit, success_json};
 
+const MAX_SEARCH_QUERY_CHARS: usize = 4_000;
+
+fn validate_search_query(query: &str) -> anyhow::Result<()> {
+    if query.chars().count() > MAX_SEARCH_QUERY_CHARS {
+        anyhow::bail!(
+            "query is too long (max {} characters)",
+            MAX_SEARCH_QUERY_CHARS
+        );
+    }
+    Ok(())
+}
+
 fn normalize_memory_content(content: &str) -> String {
     content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
@@ -55,6 +67,7 @@ fn apply_min_score(mut results: Vec<SearchResult>, min_score: Option<f32>) -> Ve
 
 pub async fn search(state: &Arc<AppState>, params: SearchParams) -> anyhow::Result<CallToolResult> {
     crate::ensure_embedding_ready!(state);
+    validate_search_query(&params.query)?;
 
     let query_embedding = state.embedding.embed(&params.query).await?;
 
@@ -80,6 +93,7 @@ pub async fn search_text(
     state: &Arc<AppState>,
     params: SearchParams,
 ) -> anyhow::Result<CallToolResult> {
+    validate_search_query(&params.query)?;
     let limit = normalize_limit(params.limit);
     let results = match state.storage.bm25_search(&params.query, limit * 3).await {
         Ok(r) => r,
@@ -99,6 +113,7 @@ pub async fn recall(state: &Arc<AppState>, params: RecallParams) -> anyhow::Resu
     use std::collections::HashMap;
 
     crate::ensure_embedding_ready!(state);
+    validate_search_query(&params.query)?;
 
     let query_embedding = state.embedding.embed(&params.query).await?;
 


### PR DESCRIPTION
### Motivation
- Закріпити валідацію вхідного тексту, щоб запобігти DoS через необмежену токенізацію/інференс або BM25-пошук від довільних великих payload.

### Description
- Додано `MAX_MEMORY_CONTENT_CHARS = 16000` та функцію `validate_memory_content` у `src/server/logic/memory.rs` і виклик цієї валідації перед викликом `embed` у `store_memory` та `update_memory`.
- Додано `MAX_SEARCH_QUERY_CHARS = 4000` та функцію `validate_search_query` у `src/server/logic/search.rs` і виклик цієї валідації в `search`, `search_text` та `recall` перед викликом embedding/BM25.
- Фікс мінімальний і обмежений до шару логіки, повертає явну помилку валідації при перевищенні ліміту і зберігає існуючу поведінку для нормальних запитів.

### Testing
- Запущено `cargo test -q`, команда стартувала в середовищі, але тестовий прогін не завершився в межах доступного часу/оточення (неможливо завершити через відсутні кешовані залежності і обмеження середовища).
- Запущено `cargo test -q --no-run`, команда також не завершилася через обмеження середовища і відсутні кешовані артефакти, тому автоматичні тести не були повністю виконані тут.
- Рекомендується виконати повний CI-прогін (`cargo test`) у середовищі з доступом до залежностей, щоб підтвердити регресійні тести та інтеграцію.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b595c94832ba91a6aa61dde548a)