### PR TITLE
fix(ci): заміна незакріпленого Swatinem/rust-cache у release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,15 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
         with:
-          key: x86_64-unknown-linux-musl
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-x86_64-unknown-linux-musl-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-x86_64-unknown-linux-musl-
 
       - name: Build MUSL
         env:
@@ -148,9 +154,15 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
         with:
-          key: ${{ matrix.target }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
 
       - name: Build
         shell: bash


### PR DESCRIPTION
### Motivation
- Статичний скан виявив критичну вразливість ланцюга постачання: релізний workflow виконує третю сторону з mutable tag `Swatinem/rust-cache@v2` перед збіркою артефактів при `permissions: contents: write`, що дозволяє потенційно отруїти релізні бінарні файли. 
- Потрібно було усунути точку виконання чужого коду в привілейованому job, зберігши при цьому поведінку кешування Cargo для швидших збірок.

### Description
- Замінено кроки `Rust Cache` у job'ах `build-musl` та `build-others` з `uses: Swatinem/rust-cache@v2` на `uses: actions/cache@v4`.
- Додано явні `path`, детерміністичні `key` (`hashFiles('**/Cargo.lock')`) та `restore-keys` для кешу `~/.cargo/registry`, `~/.cargo/git` і `target`, щоб зберегти кешування артефактів без виконання чужого коду. 
- Залишився незмінним порядок пакування й завантаження реліз-артефактів, зміни обмежені тільки реалізацією кешування.

### Testing
- Перевірено пошуком (`rg`) що `Swatinem/rust-cache@v2` більше не зустрічається в `.github/workflows` і що оновлені кроки присутні у `.github/workflows/release.yml`.
- Інспектовано оновлений файл за допомогою відображення фрагментів (`sed`/`nl`), що підтвердило наявність `actions/cache@v4` з `path`, `key` і `restore-keys` у відповідних job'ах.
- Виконано порівняння змін (`git diff`) щоб підтвердити, що правки стосуються лише реалізації кешу і не впливають на кроки збірки/пакування/загрузки; перевірки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e4cde9ac832bacb9f21fb7efa147)