### PR TITLE
fix(docker): verify release tarball integrity in Dockerfile.release

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,6 +10,7 @@ FROM alpine:3.23
 
 ARG VERSION
 ARG REPO=pomazanbohdan/memory-mcp-1file
+ARG TARBALL_SHA256
 
 # Install runtime dependencies (minimal)
 RUN apk add --no-cache ca-certificates tzdata
@@ -22,6 +23,8 @@ RUN VERSION=${VERSION:-$(cat /tmp/VERSION)} && \
     echo "Installing memory-mcp v${VERSION}" && \
     wget -q -O memory-mcp.tar.gz \
     "https://github.com/${REPO}/releases/download/v${VERSION}/memory-mcp-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    && test -n "${TARBALL_SHA256}" \
+    && echo "${TARBALL_SHA256}  memory-mcp.tar.gz" | sha256sum -c - \
     && tar -xzf memory-mcp.tar.gz \
     && mv memory-mcp /usr/local/bin/memory-mcp \
     && rm memory-mcp.tar.gz /tmp/VERSION \


### PR DESCRIPTION
### Motivation
- Усунути ризик ланцюга постачання: `Dockerfile.release` завантажував та встановлював бінарний tarball з GitHub Releases без жодної перевірки цілісності, що дозволяло підміну артефакту й виконання довільного коду.

### Description
- Додано обов’язковий аргумент збірки `TARBALL_SHA256` і перед розпакуванням виконано перевірку контрольної суми через `echo "${TARBALL_SHA256}  memory-mcp.tar.gz" | sha256sum -c -`, а також перевірку непустого значення, після якої лише при успішній верифікації виконується `tar -xzf` і встановлення бінарника; загальна логіка `wget` → `tar` → `mv` збережена.

### Testing
- Перевірив `Dockerfile.release` до й після правки (`sed`, `cat`), застосував зміни і переглянув `git diff`, зафіксував коміт (`git commit`) і вивів файл з нумерацією (`nl`) — всі кроки пройшли успішно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e46c24bc832bb7f1919b1bfab8f0)