### PR TITLE
fix(embedding): decrement queue depth for skipped short chunks

### DIFF
--- a/src/embedding/worker.rs
+++ b/src/embedding/worker.rs
@@ -158,6 +158,9 @@ impl EmbeddingWorker {
                 min_chars = MIN_EMBED_CHARS,
                 "Skipped short chunks from embedding"
             );
+            for _ in 0..skipped_short {
+                self.metrics.dec_queue();
+            }
             batch.retain(|r| r.target.is_some() || r.responder.is_some());
             if batch.is_empty() {
                 return true;


### PR DESCRIPTION
### Motivation
- Виявлено витік обліку `queue_depth` коли короткі фрагменти (short chunks) відфільтровуються в `EmbeddingWorker::process_batch` до стандартного циклу, який викликає `dec_queue()`, що може призвести до постійного throttling при масовому індексуванні коротких шматків коду.

### Description
- Додано корекцію в `src/embedding/worker.rs`: перед видаленням пропущених елементів тепер викликається `self.metrics.dec_queue()` по одному разу для кожного `skipped_short`, щоб компенсувати попереднє `inc_queue()` з черги відправки.
- Збережено існуючу поведінку пропуску коротких chunk-таргетів та відправки порожньої відповіді через `responder`, зміни стосуються лише метрик обліку черги.
- Зміна мінімальна і локалізована: лише правка обліку метрик у `process_batch` без зміни логіки інференсу або збереження в кеш.

### Testing
- Локальна інспекція файлу підтвердила вставку циклу `for _ in 0..skipped_short { self.metrics.dec_queue(); }` перед `batch.retain(...)` і передчасним `return` у випадку пустого батчу, що відповідає очікуваній компенсації метрик (статична верифікація).
- `cargo test` для відповідного воркера запускали, але виконання тестів не завершилось у сесії через блокування/довгу збірку артефактів (тест не пройшов до кінця у середовищі); тепер зміна готова до повного CI-прогона в середовищі з можливістю завершити всі збірки.
- `cargo fmt --check` викликав помилки форматування в інших файлах, відмінні від цього виправлення, тобто форматування проекту в цілому потребує окремого проходу; сам патч не вносить стилістичних змін крім вставлених рядків.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032899a1b0832b86683b3712b3a295)