### PR TITLE
fix(security): remove unpinned third-party model from default path

### DIFF
--- a/src/embedding/config.rs
+++ b/src/embedding/config.rs
@@ -16,7 +16,8 @@ pub enum EngineBackend {
 pub enum ModelType {
     /// intfloat/multilingual-e5-small — 384d, ~85 MB Q4. Legacy lightweight option.
     E5Small,
-    /// intfloat/multilingual-e5-base — 768d, ~180 MB. Legacy; kept for backward compat.
+    /// intfloat/multilingual-e5-base — 768d, ~180 MB. Legacy; kept for backward compat. Default.
+    #[default]
     E5Multi,
     /// nomic-ai/nomic-embed-text-v1.5 — 768d, ~270 MB. Long-context BERT-compatible.
     Nomic,
@@ -24,8 +25,7 @@ pub enum ModelType {
     BgeM3,
     /// Qwen/Qwen3-Embedding-0.6B — 1024d, ~1.2 GB. Top open-source 2026, MRL, 32K ctx.
     Qwen3,
-    /// unsloth/embeddinggemma-300m-qat-q4_0-unquantized — 768d, ~195 MB. Default.
-    #[default]
+    /// unsloth/embeddinggemma-300m-qat-q4_0-unquantized — 768d, ~195 MB.
     Gemma,
     Mock,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     #[arg(long, env, default_value_os_t = default_data_dir())]
     data_dir: PathBuf,
 
-    #[arg(long, env = "EMBEDDING_MODEL", default_value = "gemma")]
+    #[arg(long, env = "EMBEDDING_MODEL", default_value = "e5_multi")]
     model: String,
 
     #[arg(long, env, default_value = "1000")]
@@ -94,7 +94,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
         println!("Available models:");
         println!("  qwen3     - 1024 dim, ~1.2 GB          [Apache 2.0] Top open-source 2026, MRL, 32K ctx");
         println!(
-            "  gemma     -  768 dim, ~195 MB (default) [Gemma license] Lightweight MRL alternative"
+            "  gemma     -  768 dim, ~195 MB           [Gemma license] Lightweight MRL alternative"
         );
         println!(
             "  bge_m3    - 1024 dim, ~420 MB           [MIT] Hybrid dense+sparse+colbert retrieval"
@@ -103,7 +103,7 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
             "  nomic     -  768 dim, ~270 MB           [Apache 2.0] Long-context BERT-compatible"
         );
         println!(
-            "  e5_multi  -  768 dim, ~180 MB           [MIT] Legacy; kept for backward compat"
+            "  e5_multi  -  768 dim, ~180 MB (default) [MIT] Legacy; kept for backward compat"
         );
         println!("  e5_small  -  384 dim,  ~85 MB           [MIT] Minimal RAM, dev/testing only");
         println!();


### PR DESCRIPTION
### Motivation
- Виправлення проблеми ланцюжка постачання: рання конфігурація за замовчуванням використовувала `gemma` (репо `unsloth/...`) без зафіксованої ревізії або перевірки цілісності артефактів, через що нові інсталяції автоматично завантажували змінний upstream.
- Потрібне мінімальне, безпечне виправлення, яке не видаляє підтримку `gemma`, але виключає її зі шляху за замовчуванням нових розгортань.

### Description
- Змінено CLI default `EMBEDDING_MODEL` з `gemma` на `e5_multi` у `src/main.rs` так, щоб свіжі інсталяції не звертались автоматично до непінованого стороннього репозиторію.
- Оновлено реалізацію `ModelType` у `src/embedding/config.rs`, щоб дефолтним типом моделі був `E5Multi` (а `Gemma` залишився доступним як явний вибір).
- Відкориговано вивід `--list-models` у `src/main.rs`, щоб коректно маркувати `e5_multi` як `(default)` і прибрати мітку дефолту з `gemma`.
- Збережено підтримку `gemma` як опціональної моделі (можна ввімкнути через `EMBEDDING_MODEL=gemma`) без повторного введення в шлях запуску за замовчуванням.

### Testing
- Виконано форматування коду: `cargo fmt --all` (успішно).
- Спроба запуску `cargo check -q` була здійснена у цьому середовищі; збірка залежностей є довготривалою й у сесії не завершилась, при цьому не було зафіксовано явних помилок компіляції у виводі під час правок.
- Локальний огляд змін і `git commit` підтвердили коректність дифу та мінімальний обсяг змін (коміт: `fix(security): remove unpinned third-party model from default path`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b582514832babb9da413aa1d486)