### PR TITLE
fix(security): обмежити розгортання запитів BM25 щоб запобігти DoS

### DIFF
--- a/src/storage/surrealdb/memory_ops.rs
+++ b/src/storage/surrealdb/memory_ops.rs
@@ -88,8 +88,17 @@ pub(super) async fn bm25_search(
     // then score in Rust using term-frequency counting as a proxy for BM25.
     let fetch_limit = (limit * 3).max(limit);
 
+    const MAX_BM25_QUERY_CHARS: usize = 4096;
+    const MAX_BM25_TERMS: usize = 64;
+
+    let bounded_query: String = query.chars().take(MAX_BM25_QUERY_CHARS).collect();
+
     // Split query into individual words for multi-word matching
-    let words: Vec<&str> = query.split_whitespace().filter(|w| w.len() >= 2).collect();
+    let words: Vec<&str> = bounded_query
+        .split_whitespace()
+        .filter(|w| w.len() >= 2)
+        .take(MAX_BM25_TERMS)
+        .collect();
     if words.is_empty() {
         return Ok(vec![]);
     }
@@ -120,7 +129,7 @@ pub(super) async fn bm25_search(
     let mut results: Vec<SearchResult> = response.take(0)?;
 
     // Compute relevance score in Rust: normalized term frequency.
-    let query_lower = query.to_lowercase();
+    let query_lower = bounded_query.to_lowercase();
     let query_words: Vec<&str> = query_lower.split_whitespace().collect();
     for r in &mut results {
         let content_lower = r.content.to_lowercase();


### PR DESCRIPTION
### Motivation
- Виявлена вразливість: BM25-путь розгортає по одному SQL-предикату і bind-параметру на кожен терм запиту, що дозволяє віддаленому клієнту спричинити великі алокації та високе CPU навантаження (DoS). 
- Потрібне мінімальне обмеження вхідного запиту, щоб зберегти поточну поведінку пошуку, але уникнути неосяжного розширення кількості термів і обсягу SQL.

### Description
- Додав обмеження довжини оброблюваного запиту через константу `MAX_BM25_QUERY_CHARS = 4096` і обрізку вхідного рядка через `bounded_query` в `bm25_search` у файлі `src/storage/surrealdb/memory_ops.rs`.
- Додав обмеження на кількість термів, які використовуються для побудови умов і bind-циклу через `MAX_BM25_TERMS = 64` та `.take(MAX_BM25_TERMS)` при розбитті `bounded_query` на слова.
- Переніс шлях скорингу на використання `bounded_query` замість оригінального `query`, щоб обмежити також пер-результатну роботу підрахунку термів.
- Зміни мінімальні та зосереджені в `bm25_search`, без змін API поведінки для не перевищених запитів.

### Testing
- Запущено таргетний тест `cargo test test_bm25_search_multiword_and_special_chars -- --nocapture`, збірка залежностей почалася, але повна збірка/виконання тесту не завершилися в межах сесії через тривалий час компіляції стеку SurrealDB, отже результат тесту не отримано.
- Локальні перевірки файлу й запуск компіляції початкових crates пройшли (компіляція залежностей стартувала), без завершеного виконання цільового тесту в цій сесії.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b595a74832b9bf762b8bb18017c)