### PR TITLE
fix: запобігти повторному авто-індексуванню після видалення/скидання

### DIFF
--- a/src/codebase/manager.rs
+++ b/src/codebase/manager.rs
@@ -93,6 +93,18 @@ impl CodebaseManager {
     /// Returns the number of jobs enqueued.
     pub async fn validate_index_full(&self) -> Result<IncrementalResult> {
         let project_id = &self.project_id;
+        let status = self.state.storage.get_index_status(project_id).await?;
+
+        // If the project has no persisted index status, treat it as not indexed
+        // and skip background validation/re-indexing. This prevents periodic
+        // auto-index from recreating chunks after explicit project deletion.
+        if status.is_none() {
+            debug!(
+                project_id = %project_id,
+                "validate_index_full: skipped (no index status)"
+            );
+            return Ok(IncrementalResult::default());
+        }
 
         // 1. Scan the current directory.
         let project_path = self.project_path.clone();

--- a/src/server/logic/code/indexing.rs
+++ b/src/server/logic/code/indexing.rs
@@ -364,7 +364,7 @@ pub async fn delete_project(
         .await;
 
     let _ = state.storage.delete_index_status(&params.project_id).await;
-    let _ = state.storage.delete_file_hashes(&params.project_id).await;
+    let _ = state.storage.delete_manifest_entries(&params.project_id).await;
 
     // Remove from in-memory BM25 index
     state.code_search.remove_project(&params.project_id).await;

--- a/src/storage/surrealdb/mod.rs
+++ b/src/storage/surrealdb/mod.rs
@@ -755,6 +755,8 @@ impl StorageBackend for SurrealStorage {
             "symbol_chunk_map",
             "symbol_relation",
             "index_status",
+            "file_hashes",
+            "file_manifest",
         ];
         for table in &tables {
             let _ = self.db.query(format!("DELETE {}", table)).await;


### PR DESCRIPTION
### Motivation
- Усунути вразливість, коли фоновий авто-індексер (`/project` CodebaseManager / IndexWorker) міг повторно відновлювати індексацію видалених файлів після виклику `delete_project` або `reset_all_memory`, що призводило до повторного оприлюднення видаленого коду.

### Description
- Додано перевірку в `validate_index_full` у `src/codebase/manager.rs`, яка пропускає фонову валідацію/ре-індексацію якщо для `project_id` немає збереженого `index_status` (ранній `return`).
- Змінено `delete_project` у `src/server/logic/code/indexing.rs` так, щоб воно очищало `file_manifest` (`delete_manifest_entries`) замість лише видалення `file_hashes`, щоб не залишати метадані, які могли спровокувати повторну індексацію.
- Розширено `reset_db` у `src/storage/surrealdb/mod.rs`, додавши таблиці `file_hashes` та `file_manifest` до переліку, що очищається при повному скиданні БД, щоб «повний reset» дійсно видаляв нові метадані індексації.

### Testing
- Запущено `cargo test -q`, але команда не повернула результат у виділений час виконання (інфраструктурне/часове обмеження), тому результати тестів невизначені.
- Запущено `timeout 180 cargo check -q`, який також не завершився з релевантним виводом у межах сесії, отже перевірка збірки інконукова.
- Запущено `cargo check --offline -q`, який не повернув результат у доступному вікні виконання, тому автоматичні збіркові перевірки залишилися неуспішними/неінформативними.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b596c54832b92a8866a83306f12)