### PR TITLE
fix(indexer): кешувати символи проєкту в `incremental_index` щоб уникнути повторних повних завантажень

### DIFF
--- a/src/codebase/indexer.rs
+++ b/src/codebase/indexer.rs
@@ -467,6 +467,7 @@ pub async fn incremental_index(
     changed_paths: Vec<std::path::PathBuf>,
 ) -> Result<IncrementalResult> {
     let mut result = IncrementalResult::default();
+    let mut cached_project_symbols: Option<Vec<CodeSymbol>> = None;
     // Keep a local alias for the previous `updated` counter used inside the macro.
     macro_rules! inc_updated {
         () => {
@@ -549,8 +550,11 @@ pub async fn incremental_index(
 
             if !all_refs.is_empty() {
                 let mut symbol_index = SymbolIndex::new();
-                if let Ok(all_symbols) = state.storage.get_project_symbols(project_id).await {
-                    symbol_index.add_batch(&all_symbols);
+                if cached_project_symbols.is_none() {
+                    cached_project_symbols = state.storage.get_project_symbols(project_id).await.ok();
+                }
+                if let Some(all_symbols) = &cached_project_symbols {
+                    symbol_index.add_batch(all_symbols);
                 }
                 symbol_index.add_batch(&symbols);
                 let _stats = create_symbol_relations(


### PR DESCRIPTION
### Motivation
- Уникнути локального DoS-вектора, де `incremental_index` викликає `get_project_symbols` для кожного файлу зі змінами й багаторазово матеріалізує весь набір символів проєкту в пам’яті. 
- Зберегти існуючу поведінку cross-file relation resolution при одночасному зменшенні витрат пам’яті під час сплесків змін файлів.

### Description
- Додано локальний кеш `cached_project_symbols: Option<Vec<CodeSymbol>>` у функцію `incremental_index` для зберігання результату `get_project_symbols` на час одного виклику. 
- При створенні відношень тепер спочатку наповнюється `symbol_index` із закешованих символів (якщо є), а потім додаються символи поточного файла, замість повторного виконання `get_project_symbols` для кожного файлу. 
- Зміна мінімальна і локалізована лише в шляху інкрементального індексування, поведінка повного індексу не змінювалась.

### Testing
- Спроба запустити `cargo test -q test_indexer_batching` та `cargo test -q test_indexer_batching -- --nocapture` була виконана, але у цьому середовищі запуск не повернув завершений результат у відведений час. 
- Статичний огляд коду та локальна перевірка логіки підтверджують, що зміна запобігає повторним повним завантаженням символів під час одного виклику `incremental_index` і тим самим зменшує ризик виснаження пам’яті.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b57f34c832bbded1e8c969df138)