### PR TITLE
fix: обмежити ріст SymbolIndex у пам'яті під час індексації

### DIFF
--- a/src/codebase/symbol_index.rs
+++ b/src/codebase/symbol_index.rs
@@ -20,7 +20,13 @@ impl ResolutionContext {
 #[derive(Debug, Default)]
 pub struct SymbolIndex {
     by_name: HashMap<String, Vec<SymbolRef>>,
+    total_symbols: usize,
 }
+
+/// Hard safety limits for in-memory symbol accumulation during project indexing.
+/// These caps prevent unbounded attacker-controlled growth from exhausting RAM.
+const MAX_TOTAL_SYMBOLS: usize = 200_000;
+const MAX_SYMBOLS_PER_NAME: usize = 256;
 
 impl SymbolIndex {
     pub fn new() -> Self {
@@ -29,11 +35,18 @@ impl SymbolIndex {
 
     /// Add a symbol to the index.
     pub fn add(&mut self, symbol: &CodeSymbol) {
+        if self.total_symbols >= MAX_TOTAL_SYMBOLS {
+            return;
+        }
+
         let sym_ref = SymbolRef::from_symbol(symbol);
-        self.by_name
-            .entry(symbol.name.clone())
-            .or_default()
-            .push(sym_ref);
+        let entry = self.by_name.entry(symbol.name.clone()).or_default();
+        if entry.len() >= MAX_SYMBOLS_PER_NAME {
+            return;
+        }
+
+        entry.push(sym_ref);
+        self.total_symbols += 1;
     }
 
     /// Add multiple symbols to the index.
@@ -63,6 +76,11 @@ impl SymbolIndex {
     /// Total number of unique names in the index.
     pub fn len(&self) -> usize {
         self.by_name.len()
+    }
+
+    /// Total number of symbol refs retained in memory.
+    pub fn total_symbols(&self) -> usize {
+        self.total_symbols
     }
 
     /// Check if the index is empty.
@@ -139,5 +157,26 @@ mod tests {
         let index = SymbolIndex::new();
         let ctx = ResolutionContext::new("/src/a.rs".to_string());
         assert!(index.resolve("nonexistent", &ctx).is_none());
+    }
+
+    #[test]
+    fn test_per_name_cap() {
+        let mut index = SymbolIndex::new();
+        for i in 0..(MAX_SYMBOLS_PER_NAME as u32 + 10) {
+            index.add(&make_symbol("dup", &format!("/src/{i}.rs"), i));
+        }
+
+        let retained = index.get_all("dup").map_or(0, Vec::len);
+        assert_eq!(retained, MAX_SYMBOLS_PER_NAME);
+    }
+
+    #[test]
+    fn test_total_cap() {
+        let mut index = SymbolIndex::new();
+        for i in 0..(MAX_TOTAL_SYMBOLS as u32 + 10) {
+            index.add(&make_symbol(&format!("name_{i}"), &format!("/src/{i}.rs"), i));
+        }
+
+        assert_eq!(index.total_symbols(), MAX_TOTAL_SYMBOLS);
     }
 }


### PR DESCRIPTION
### Motivation
- Виправити вразливість DoS: `SymbolIndex` раніше накопичував усі знайдені посилання без обмежень, що дозволяло атакуючому викликати виснаження пам'яті під час індексації проєкту.
- Мінімальна зміна потрібна для швидкої безпечної міграції поведінки без руйнування існуючої логіки розв'язання символів.

### Description
- Додано поле `total_symbols` і два жорсткі ліміти: `MAX_TOTAL_SYMBOLS` (глобальний) та `MAX_SYMBOLS_PER_NAME` (на ім'я) в `src/codebase/symbol_index.rs` для обмеження обсягу збережених `SymbolRef`.
- Оновлено `add()` так, щоб воно припиняло додавання, коли будь-який з лімітів досягається, ітеративно зберігаючи існуючий порядок та поведінку розв'язання.
- Додано доступор `total_symbols()` і тести одиниць `test_per_name_cap` та `test_total_cap`, що перевіряють поведінку пер-нейм і глобального обмеження.
- Зміни зосереджені в `symbol_index.rs` як мінімальне пом'якшення; існуюча логіка пакетного/проміжного скидання зв'язків у `indexer.rs` залишена без змін.

### Testing
- Додано два автоматичні юніт-тести: `test_per_name_cap` і `test_total_cap` у модулі тестів `symbol_index` для валідації пер-нейм та глобального капа, і вони включені в репо.
- Спроба виконати `cargo test symbol_index::tests::test_per_name_cap -- --nocapture` у цьому середовищі розпочала збірку, але збірка була тривалою і не завершилась у виділеному часі, тому результат тесту тут не підтверджено (середовище обмежило час виконання).
- Диф змін файлу показує додані ліміти, оновлену логіку `add()` та нові тести; немає змін до поведінки розв'язання символів поза випадками відкидання додаткових записів при досягненні капів.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b57cda8832bb0c0dd734a8ecda3)