### PR TITLE
fix: очищення in-memory BM25 індексу при reset_all_memory

### DIFF
--- a/src/search/bm25.rs
+++ b/src/search/bm25.rs
@@ -305,6 +305,11 @@ impl CodeSearchEngine {
         self.projects.write().await.remove(project_id);
     }
 
+    /// Clear all in-memory BM25 project indexes.
+    pub async fn clear_all(&self) {
+        self.projects.write().await.clear();
+    }
+
     /// Add or update individual chunks in the index (called after incremental indexing).
     ///
     /// `chunks` is a `(ChunkMeta, content)` pair — `content` is used only to

--- a/src/server/logic/system.rs
+++ b/src/server/logic/system.rs
@@ -83,6 +83,7 @@ pub async fn reset_all_memory(
     }
 
     state.storage.reset_db().await?;
+    state.code_search.clear_all().await;
 
     Ok(success_json(json!({
         "reset": true,
@@ -93,8 +94,9 @@ pub async fn reset_all_memory(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::search::ChunkMeta;
     use crate::test_utils::TestContext;
-    use crate::types::{Memory, MemoryType};
+    use crate::types::{ChunkType, Language, Memory, MemoryType};
 
     #[tokio::test]
     async fn test_system_logic() {
@@ -121,6 +123,27 @@ mod tests {
             })
             .await
             .unwrap();
+        ctx.state
+            .code_search
+            .upsert_chunks(
+                "proj-reset",
+                vec![(
+                    ChunkMeta {
+                        id: "chunk-1".to_string(),
+                        file_path: "src/private.rs".to_string(),
+                        language: Language::Rust,
+                        start_line: 1,
+                        end_line: 5,
+                        chunk_type: ChunkType::Function,
+                        name: Some("secret_fn".to_string()),
+                        context_path: None,
+                        project_id: "proj-reset".to_string(),
+                    },
+                    "secret token".to_string(),
+                )],
+            )
+            .await;
+        assert_eq!(ctx.state.code_search.chunk_count("proj-reset").await, 1);
 
         // 1. Get Status
         let status_params = GetStatusParams {
@@ -151,5 +174,6 @@ mod tests {
         assert!(success_json.get("reset").is_some());
 
         assert_eq!(ctx.state.storage.count_memories().await.unwrap(), 0);
+        assert_eq!(ctx.state.code_search.chunk_count("proj-reset").await, 0);
     }
 }


### PR DESCRIPTION
### Motivation

- Після `reset_all_memory` база даних очищалась через `state.storage.reset_db()`, але in-memory BM25 індекс (`state.code_search`) лишався незачищеним, що дозволяло витікати метаданим старих індексованих фрагментів коду.

### Description

- Додано метод `CodeSearchEngine::clear_all()` у `src/search/bm25.rs`, який очищає всі per-project BM25 індекси в пам'яті.
- Викликаю `state.code_search.clear_all().await;` в `reset_all_memory` у `src/server/logic/system.rs` одразу після `state.storage.reset_db().await?;` щоб гарантовано очищати не тільки БД, а й пам'ять процесу.
- Розширено тест `test_system_logic` у `src/server/logic/system.rs`, який додає штучний chunk у `code_search`, перевіряє наявність перед reset і підтверджує, що після `reset_all_memory` in-memory індекс порожній (`chunk_count == 0`).

### Testing

- Запущено `cargo test test_system_logic`; збірка/тестування почалося і пройшло фазу компіляції залежностей, але повна прогонка тестів не встигла завершитись у межах сесії через тривалу компіляцію середовищних залежностей. Тест, що доданий, перевіряє, що `code_search` переходить від `1` до `0` після reset.
- Спроба `cargo test test_system_logic --package memory-mcp-1file` повернула помилку через некоректний package ID, тому вона була пропущена.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b59d758832bb45eaed5624c513d)