### PR TITLE
fix(security): обмежити витік локальних шляхів у статусі індексації

### DIFF
--- a/src/codebase/indexer.rs
+++ b/src/codebase/indexer.rs
@@ -58,12 +58,16 @@ pub async fn index_project(state: Arc<AppState>, project_path: &Path) -> Result<
                 status = existing;
             }
 
-            // Extract last known file if possible
+            // Extract last known file if possible (store file name only to avoid path disclosure)
             if let Some(monitor) = state.progress.get(&project_id).await {
                 if let Ok(cf) = monitor.current_file.read() {
                     if !cf.is_empty() {
-                        status.failed_files.push(cf.clone());
-                        status.error_message = Some(format!("{}: Failed at file {}", e, cf));
+                        let safe_name = Path::new(&*cf)
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("unknown");
+                        status.failed_files.push(safe_name.to_string());
+                        status.error_message = Some(format!("{}: Failed at file {}", e, safe_name));
                     } else {
                         status.error_message = Some(e.to_string());
                     }
@@ -272,12 +276,16 @@ async fn do_index_project(
     }
 
     for file_path in &files {
-        // Update current file in monitor for status reporting
+        // Update current file in monitor for status reporting (file name only)
         if let Ok(mut cf) = monitor.current_file.write() {
-            *cf = file_path.to_string_lossy().to_string();
+            *cf = file_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string();
         }
 
-        tracing::info!("Indexing file: {:?}", file_path);
+        tracing::debug!(file = %file_path.display(), "Indexing file");
 
         // Skip auto-generated files (no useful semantic content)
         if crate::codebase::scanner::is_ignored_file(file_path) {

--- a/src/server/logic/code/indexing.rs
+++ b/src/server/logic/code/indexing.rs
@@ -136,16 +136,16 @@ pub async fn get_index_status(
         Ok(Some(mut status)) => {
             let mut current_file: Option<String> = None;
 
-            // Always try to fetch current_file from monitor if available, even if failed or stuck
             if let Some(monitor) = state.progress.get(&params.project_id).await {
-                if let Ok(cf) = monitor.current_file.read() {
-                    if !cf.is_empty() {
-                        current_file = Some(cf.clone());
-                    }
-                }
-
-                // If we are actively indexing, update the progress counters
+                // Show current file only while indexing is active.
                 if status.status == crate::types::IndexState::Indexing {
+                    if let Ok(cf) = monitor.current_file.read() {
+                        if !cf.is_empty() {
+                            current_file = Some(cf.clone());
+                        }
+                    }
+
+                    // If we are actively indexing, update the progress counters
                     let indexed = monitor
                         .indexed_files
                         .load(std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
### Motivation
- Виявлено витік метаданих шляхів файлів через пер-файлові `info`-логи та поля статусу індексації, що дозволяє отримати локальні абсолютні шляхи через API або логи.
- Мета змін — мінімізувати розкриття локальної структури файлів при збереженні корисної інформації про прогрес індексації.

### Description
- Змінено `src/codebase/indexer.rs` так, щоб у моніторі прогресу `current_file` зберігався лише базовий імʼя файлу (basename) замість повного шляху для запобігання розкриттю директорій, і цей basename використовують у `failed_files` та `error_message` при помилці.
- Знижено рівень логування пер-файлових повідомлень з `tracing::info!` на `tracing::debug!` і зроблено структурне логування поля `file` замість виводу повного шляху у повідомленні, щоб за замовчуванням (info) шляхи не виводились у stderr.
- У `src/server/logic/code/indexing.rs` поле `current_file`, яке повертається `get_index_status`, тепер читається та повертається лише коли статус індексації активний (`Indexing`), щоб уникнути повернення «stale» значень після `Completed` або `Failed`.
- Файли змін: `src/codebase/indexer.rs` і `src/server/logic/code/indexing.rs` і відповідні місця, де формуються `failed_files`/`error_message` та формуються логи.

### Testing
- Запущено `cargo test -q`, збірка триває у цьому середовищі й не завершилась у розумний час (неповний/недетермінований результат).
- Запущено `cargo check` та `timeout 20 cargo check`, обидва виявилися заблоковані/таймаутовані через очікування file lock або тривалу компіляцію у цьому середовищі.
- Статичний огляд коду та цільова перевірка змінених місць підтвердили, що більше не зберігаються повні шляхи у `failed_files`/`error_message` і що логування на рівні `info` більше не виводить повні шляхи (переведено в `debug`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b57d4a8832b9916ab4f0d8f5932)