### PR TITLE
fix(security): redact current indexing path in status

### DIFF
--- a/src/codebase/indexer.rs
+++ b/src/codebase/indexer.rs
@@ -274,7 +274,10 @@ async fn do_index_project(
     for file_path in &files {
         // Update current file in monitor for status reporting
         if let Ok(mut cf) = monitor.current_file.write() {
-            *cf = file_path.to_string_lossy().to_string();
+            *cf = file_path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "<unknown>".to_string());
         }
 
         tracing::info!("Indexing file: {:?}", file_path);


### PR DESCRIPTION
### Motivation
- Усунути витік чутливих абсолютних шляхів у полі `current_file` статусу індексації, яке могло розкривати локальні шляхи та імена користувачів через виклики `get_index_status`.

### Description
- Зроблено мінімальну зміну в `src/codebase/indexer.rs`: замість збереження повного шляху (`file_path.to_string_lossy().to_string()`) у прогрес-монітор тепер зберігається тільки ім'я файлу через `file_name()` з безпечним fallback `"<unknown>"`, зберігаючи форму API `parsing.current_file`.

### Testing
- Спроба запустити автоматичні тести у цьому середовищі була виконана з `cargo test -q --no-run`, але команда не завершилась у доступному вікні виконання, тому повна перевірка збірки/тестів тут не відбулась.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b5817c8832bba37323b16a40866)