### PR TITLE
fix: не індексувати файли з прихованих компонентів шляху

### DIFF
--- a/src/codebase/indexer.rs
+++ b/src/codebase/indexer.rs
@@ -574,6 +574,13 @@ pub async fn incremental_index(
     for path in changed_paths {
         let path_str = path.to_string_lossy().to_string();
 
+        if crate::codebase::scanner::is_ignored_file(&path)
+            || !crate::codebase::scanner::is_code_file(&path)
+        {
+            tracing::debug!(path = %path_str, "Skipping ignored/non-code file from watcher event");
+            continue;
+        }
+
         if !path.exists() {
             match state
                 .storage

--- a/src/codebase/scanner.rs
+++ b/src/codebase/scanner.rs
@@ -123,16 +123,20 @@ pub fn is_ignored_file(path: &Path) -> bool {
         }
     }
 
+    // Hidden path components (e.g. .secret/token.py or .venv/lib/site.py)
+    // should be excluded consistently for both scanner and watcher paths.
+    if path.components().any(|component| {
+        let part = component.as_os_str().to_string_lossy();
+        part.starts_with('.') && part != "." && part != ".."
+    }) {
+        return true;
+    }
+
     let name = path
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .to_lowercase();
-
-    // Hidden files (dotfiles)
-    if name.starts_with('.') && name != "." {
-        return true;
-    }
 
     // Lock files
     if matches!(


### PR DESCRIPTION
### Motivation
- Виправити регресію, коли події від `FileWatcher` могли приводити до індексації файлів, що знаходяться всередині прихованих директорій (наприклад `.venv/`, `.secret/`), через те, що `is_ignored_file()` перевіряв лише останній компонент шляху. 
- Додати defense-in-depth у потокі incremental indexing, щоб подія від watcher не призводила до читання й індексації небажаних (ignored/non-code) шляхів.

### Description
- `src/codebase/scanner.rs`: `is_ignored_file()` тепер перевіряє всі компоненти шляху через `path.components().any(...)` і повертає `true` якщо будь-який компонент починається з `.` (окрім `.`/`..`), відновлюючи виключення прихованих директорій на рівні предиката сканера.
- `src/codebase/indexer.rs`: у `incremental_index()` додано початкову перевірку `if is_ignored_file(&path) || !is_code_file(&path)` щоб пропустити події watcher для ігнорованих або не-кодових файлів перед виконанням `read_to_string` та подальшої обробки.
- Файли змінені: `src/codebase/scanner.rs`, `src/codebase/indexer.rs` (мінімальні та локалізовані правки без зміни логіки chunking/parsing).

### Testing
- Виконано форматування коду за допомогою `cargo fmt` (успіх).
- Спроба запустити `cargo test -q` була зроблена в цьому середовищі, але тестовий прогін не дав конклюзивного виводу тут; рекомендую CI запуск для повної перевірки тестів.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b5983dc832b8c4d7afad615ee52)