### PR TITLE
fix(embedding): відхилення порожніх токен-послідовностей у Qwen3 перед інференсом

### DIFF
--- a/src/embedding/engine.rs
+++ b/src/embedding/engine.rs
@@ -184,6 +184,9 @@ impl EmbeddingEngine {
                 if token_ids.len() > max_len {
                     token_ids.truncate(max_len);
                 }
+                if token_ids.is_empty() {
+                    anyhow::bail!("Cannot embed empty token sequence");
+                }
 
                 match &self.inner {
                     InnerModel::Bert(model) => {


### PR DESCRIPTION
### Motivation
- Декодерні токенізатори (Qwen-style) можуть повертати пустий вектор `token_ids` для порожнього рядка, що в одиночному Qwen3-потоці призводило до обчислення `seq_len - 1` і можливого підзаповнення/паніки при виклику моделі нині, коли `qwen3` є дефолтною моделлю.
- Потрібен мінімальний захист, який запобігає передачі нуль-довжини тензорів у `forward` і робить поведінку одиночного шляху узгодженою з уже існуючою перевіркою в батч-шляху.

### Description
- Додано ранню перевірку після усікання `token_ids`: `if token_ids.is_empty() { anyhow::bail!("Cannot embed empty token sequence"); }` у `EmbeddingEngine::embed` у файлі `src/embedding/engine.rs`, щоб відхилити порожні послідовності до створення `Tensor::new` або виклику `model.forward`.
- Залишено існуючу поведінку для непорожніх вхідних даних і узгоджено одиночний шлях з обробкою порожніх елементів у батч-шляху (який вже повертав `None`/журналив пропуск).
- Зміна є мінімальною та не вводить нової функціональності, лише захист від аварійних випадків пов'язаних з нуль-довжиною токенів.

### Testing
- Спроба запустити `cargo test -q` у цьому середовищі завершилася таймаутом (`timeout 60 cargo test -q` → `EXIT:124`), тому автоматичні тести не були підтверджені тут.
- Зроблено локальний огляд коду та перевірено, що додана перевірка знаходиться безпосередньо перед створенням тензора/викликом моделі, і що вона не впливає на інші гілки коду; коміт створено успішно з повідомленням `fix(embedding): reject empty token sequences before inference`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b5951d8832b977699d2a7dc6f48)