### PR TITLE
fix(reset): clear file_hashes during global reset

### DIFF
--- a/src/storage/surrealdb/mod.rs
+++ b/src/storage/surrealdb/mod.rs
@@ -755,6 +755,7 @@ impl StorageBackend for SurrealStorage {
             "symbol_chunk_map",
             "symbol_relation",
             "index_status",
+            "file_hashes",
         ];
         for table in &tables {
             let _ = self.db.query(format!("DELETE {}", table)).await;
@@ -1100,6 +1101,16 @@ mod tests {
         storage.reset_db().await.unwrap();
 
         assert_eq!(storage.count_memories().await.unwrap(), 0);
+
+        // file_hashes metadata must also be cleared by global reset
+        let hashes: Vec<surrealdb::sql::Value> = storage
+            .db
+            .query("SELECT * FROM file_hashes")
+            .await
+            .unwrap()
+            .take(0)
+            .unwrap();
+        assert!(hashes.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Після введення таблиці `file_hashes` глобальний шлях скидання (`reset_db` → `reset_all_memory`) не видаляв ці записи, що призводило до витоку метаданих (шляхи файлів і їхні BLAKE3-хеші) після «повного» скиду бази.

### Description
- Додано `"file_hashes"` до масиву таблиць, які видаляються в `reset_db` в `src/storage/surrealdb/mod.rs`, щоб глобальний скидання видаляв також інкрементні метадані індексації.
- Розширено `test_reset_db` у тій самій тестовій секції, додавши прямий `SELECT * FROM file_hashes` та перевірку, що результати порожні, щоб захиститися від регресій.
- Зміни закомічено під повідомленням `fix(reset): clear file_hashes during global reset` і торкнулися лише глобального шляху скидання та тесту перевірки.

### Testing
- Запущено `cargo test test_reset_db -- --nocapture`; збірка і прогін тестів успішно стартували, але повний прогін тестів не встиг завершитися в межах цієї сесії (компіляція залежностей виконувалася успішно до моменту зупинки).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b59867c832b89142388faecdf23)