### PR TITLE
fix(ci): видалити застарілий `--features accelerate` для macOS у CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
               FEATURES=""
               ;;
             *-apple-darwin)
-              FEATURES="--features accelerate"
+              FEATURES=""
               ;;
           esac
           


### PR DESCRIPTION
### Motivation
- Після видалення фічі `accelerate` з `Cargo.toml` CI та релізні воркфлоу для macOS продовжували передавати `--features accelerate`, що призводило до помилок Cargo при розв'язанні фіч і руйнувало macOS збірки.

### Description
- У файлі `.github/workflows/ci.yml` в блоці `Compile dependencies` для `*-apple-darwin` замінено `FEATURES="--features accelerate"` на `FEATURES=""`, тим самим припинено передачу неіснуючої фічі до `cargo build`.
- Зміна мінімальна і торкається лише CI-скрипту; ніяких змін у коді чи залежностях не зроблено.

### Testing
- Виконано пошук по репозиторію командою `rg -n "accelerate|--features" .github/workflows Cargo.toml` і підтверджено відсутність `--features accelerate` у оновленому workflow; команда завершилася успішно.
- Переглянуто та зафіксовано діфф командою `git diff -- .github/workflows/ci.yml`, коміт створено (`git commit`) і `git status --short` показав чистий робочий стан; всі перевірки успішні.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b595198832b85937dd4d152327c)