### PR TITLE
fix(indexer): зберегти форвардні зв'язки символів

### DIFF
--- a/src/codebase/indexer.rs
+++ b/src/codebase/indexer.rs
@@ -230,22 +230,9 @@ async fn do_index_project(
             relation_buffer.extend(references);
             relation_buffer.extend(containment_refs);
 
-            // Mid-flight flush: avoid unbounded growth of relation_buffer on
-            // large codebases.  5000 relations ≈ ~2 MB (each CodeReference is
-            // small), so flushing at this threshold keeps peak RSS low.
-            if relation_buffer.len() >= 5000 {
-                let batch = std::mem::take(&mut relation_buffer);
-                let stats = create_symbol_relations(
-                    state.storage.as_ref(),
-                    project_id,
-                    &batch,
-                    &symbol_index,
-                )
-                .await;
-                total_relation_stats.created += stats.created;
-                total_relation_stats.failed += stats.failed;
-                total_relation_stats.unresolved += stats.unresolved;
-            }
+            // Keep references buffered until all symbols are indexed.
+            // This preserves forward references to symbols defined later
+            // in the scan order.
 
             status.indexed_files += 1;
             monitor


### PR DESCRIPTION
### Motivation
- Проміжний злив буфера зв'язків (`relation_buffer`) під час індексації призводив до втрати коректних внутрішніх (forward) відношень, оскільки цільні символи могли бути проіндексовані пізніше в проході і тоді вже не могли бути відновлені.

### Description
- Видалено mid‑flight flush у `src/codebase/indexer.rs` і повернуто поведінку: `relation_buffer` накопичується і обробляється після повного індексування символів, що запобігає втраті валідних зв'язків; зміни мінімальні і направлені на збереження цілісності графа символів.

### Testing
- Спроба запустити `timeout 60 cargo check -q` у цьому середовищі завершилась таймаутом (`EXIT:124`), тому повна перевірка збірки/тестів не відбулася; зміна коду застосована і закомічена як `fix(indexer): preserve forward symbol relations`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b59315c832b9a5944120d29cef1)