### PR TITLE
fix(symbol-relations): повернути `in`/`out` поля в API-відповідях

### DIFF
--- a/src/types/symbol.rs
+++ b/src/types/symbol.rs
@@ -243,10 +243,10 @@ pub struct SymbolRelation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Thing>,
 
-    #[serde(rename = "in", skip_serializing)]
+    #[serde(rename = "in")]
     pub from_symbol: Thing,
 
-    #[serde(rename = "out", skip_serializing)]
+    #[serde(rename = "out")]
     pub to_symbol: Thing,
 
     pub relation_type: CodeRelationType,


### PR DESCRIPTION
### Motivation
- Виправити регресію, через яку `SymbolRelation` серіалізувався без полів `in`/`out`, через що клієнти не могли відновити джерело/ціль ребра в `get_related_symbols`.

### Description
- Видалено `skip_serializing` з полів `SymbolRelation.from_symbol` і `SymbolRelation.to_symbol` у `src/types/symbol.rs`, зберігши `#[serde(rename = "in")]` та `#[serde(rename = "out")]`, при цьому десеріалізація та внутрішня логіка не змінені.

### Testing
- Запущено `cargo test test_dart_extends_implements`, виконання не завершилось у межах доступного часу в цьому середовищі (статус не отримано).
- Запущено `cargo check`, команда також не завершилась у відведений час; зміна мінімальна й обмежується поведінкою JSON-серіалізації полів.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b57df48832b949ed7fc0fef13a7)